### PR TITLE
Unpluralize `extra.flarum-extension.category`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "extra": {
         "flarum-extension": {
             "title": "User Map Location",
-            "category": "features",
+            "category": "feature",
             "icon": {
                 "name": "fas fa-map-marked-alt",
                 "backgroundColor": "purple",


### PR DESCRIPTION
All other extensions use singular, which seems to be the correct way to do it